### PR TITLE
fix(mobile/qna): clear stale errorMessage on resubmit

### DIFF
--- a/apps/mobile/packages/qna/lib/src/controllers/qna_controller.dart
+++ b/apps/mobile/packages/qna/lib/src/controllers/qna_controller.dart
@@ -138,6 +138,9 @@ class QnaController extends GetxController {
     // 0. 중복 제출 방지
     if (isSubmitting.value) return;
 
+    // 이전 API 에러 메시지 초기화
+    errorMessage.value = '';
+
     // 1. 입력 검증
     validateTitle();
     validateBody();
@@ -148,7 +151,6 @@ class QnaController extends GetxController {
     try {
       // 2. 로딩 시작
       isSubmitting.value = true;
-      errorMessage.value = '';
 
       // 3. API 호출
       await _repository.submitQuestion(


### PR DESCRIPTION
## Summary
- `submitQuestion()`에서 validation 실패 시 이전 API 에러 메시지가 남아있는 버그 수정
- `errorMessage.value = ''` 초기화를 try 블록 안에서 validation 이전으로 이동

## Changes
- `qna_controller.dart`: `errorMessage` 초기화를 중복 제출 방지 guard 직후, validation 직전으로 이동하여 모든 exit path에서 stale state가 제거되도록 수정

## Test plan
- [ ] 질문 제출 → API 에러 발생 → 에러 모달 확인 → 모달 닫기
- [ ] 제목/본문 비우고 재제출 → validation 실패 시 이전 API 에러 텍스트가 보이지 않는지 확인
- [ ] 정상 재제출 시 기존 플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 질문 제출 시 이전 API 오류 메시지가 더 이상 표시되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->